### PR TITLE
[Fix] Remove separate farmer report upload endpoint

### DIFF
--- a/src/app/home/modal/submit-report-modal.page.ts
+++ b/src/app/home/modal/submit-report-modal.page.ts
@@ -96,29 +96,16 @@ export class SubmitReportModalPage implements OnInit, OnDestroy {
     this.isSubmitted = true;
 
     this.subscriptions.add(
-      this.farmerReportService.submitFarmerReport(body).subscribe(
-        (data) => {
-          this.uploadPhoto(data);
-        },
-        async (error) => {
-          this.isSubmitted = false;
-          await this.toast('Failed to submit farmer report');
-        },
-      ),
-    );
-  }
-
-  public uploadPhoto(farmerReport: FarmerReport) {
-    this.subscriptions.add(
       this.farmerReportService
-        .uploadFarmerReportImage(farmerReport, this.currentPhoto)
+        .submitFarmerReport(body, this.currentPhoto)
         .subscribe(
           async (data) => {
             this.modalController.dismiss({ success: true });
             await this.toast('Successfully submitted farmer report');
           },
           async (error) => {
-            await this.toast('Failed to upload image: ' + error.message);
+            this.isSubmitted = false;
+            await this.toast('Failed to submit farmer report');
           },
         ),
     );

--- a/src/app/services/farmer-report.service.ts
+++ b/src/app/services/farmer-report.service.ts
@@ -15,22 +15,17 @@ import { Farmland } from '../types/farmland.type';
 export class FarmerReportService {
   constructor(private http: HttpClient) {}
 
-  public submitFarmerReport(body: FarmerReportBody): Observable<FarmerReport> {
-    return this.http
-      .post<FarmerReport>('/api/farmer-reports', body)
-      .pipe(map((data) => data));
-  }
-
-  public uploadFarmerReportImage(
-    { id }: FarmerReport,
-    { dataUrl }: FarmerReportPhoto,
-  ): Observable<void> {
+  public submitFarmerReport(
+    body: FarmerReportBody,
+    photo: FarmerReportPhoto,
+  ): Observable<FarmerReport> {
     const formData = new FormData();
-    formData.append('image', this.dataURIToBlob(dataUrl));
+    formData.append('image', this.dataURIToBlob(photo.dataUrl));
+    formData.append('data', JSON.stringify(body.farmerReport));
 
     return this.http
-      .post<FarmerReport>(`/api/farmer-reports/${id}/upload`, formData)
-      .pipe(map((data) => {}));
+      .post<FarmerReport>('/api/farmer-reports', formData)
+      .pipe(map((data) => data));
   }
 
   public getFarmerReports({ id }: Farmland): Observable<FarmerReport[]> {


### PR DESCRIPTION
<!--
Please don't open huge pull requests and keep one pull request solving one problem.
-->

### Proposed changes

- This is in support of the new farmer report API changes [here](https://github.com/radical-doubting/anikultura-backend/pull/121/commits/e206dcbccab747c8b82f931f498caae82c18549d). The farmer upload endpoint is no longer necessary since submission (including image upload) happens in one request.
